### PR TITLE
COMP: Use np.int32 over np.int

### DIFF
--- a/test_spatial_image.py
+++ b/test_spatial_image.py
@@ -110,7 +110,7 @@ def test_time_coord_type_check():
     coords = {
         "x": np.arange(4, dtype=np.float64),
         "y": np.arange(3, dtype=np.float64),
-        "t": np.arange(2, dtype=np.int),
+        "t": np.arange(2, dtype=np.int32),
     }
     dims = ("t", "y", "x")
     image = si.to_spatial_image(array, dims=dims, coords=coords)


### PR DESCRIPTION
Addresses:

test_spatial_image.py::test_time_coord_type_check
  /home/matt/src/spatial-image/test_spatial_image.py:113:
  DeprecationWarning: `np.int` is a deprecated alias for the builtin
  `int`. To silence this warning, use `int` by itself. Doing this will
  not modify any behavior and is safe. When replacing `np.int`, you may
  wish to use e.g. `np.int64` or `np.int32` to specify the precision. If
  you wish to review your current use, check the release note link for
  additional information.
    Deprecated in NumPy 1.20; for more details and guidance:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
        "t": np.arange(2, dtype=np.int),
