### PR TITLE
Add rgb argument to to_spatial_image

### DIFF
--- a/spatial_image.py
+++ b/spatial_image.py
@@ -1148,7 +1148,7 @@ def to_spatial_image(
     axis_units: Optional[Union[Mapping[Hashable, str]]] = None,
     t_coords: Optional[Sequence[Union[AllInteger, AllFloat, np.datetime64]]] = None,
     c_coords: Optional[Sequence[Union[AllInteger, str]]] = None,
-    rgb: Optional[bool] = None,
+    rgb: Optional[bool] = False,
 ) -> SpatialImage:
     """Convert the array-like to a spatial-image.
 

--- a/spatial_image.py
+++ b/spatial_image.py
@@ -1148,6 +1148,7 @@ def to_spatial_image(
     axis_units: Optional[Union[Mapping[Hashable, str]]] = None,
     t_coords: Optional[Sequence[Union[AllInteger, AllFloat, np.datetime64]]] = None,
     c_coords: Optional[Sequence[Union[AllInteger, str]]] = None,
+    rgb: Optional[bool] = None,
 ) -> SpatialImage:
     """Convert the array-like to a spatial-image.
 
@@ -1186,6 +1187,11 @@ def to_spatial_image(
         A sequence of integers by default but can be strings describing the
         channels, e.g. ['r', 'g', 'b'].
 
+    rgb: boolean, optional
+        Whether to interpret image channels as RGB. If True, override 'c_coords' and
+        assign ['r', 'g', 'b'] (or 'a') as channel names. If None, auto-detect based on
+        whether 'c_coords' is not explicitly provided and length of 'c' is 3 or 4.
+
     Returns
     -------
 
@@ -1221,6 +1227,13 @@ def to_spatial_image(
         "axis_units": axis_units,
     }
     if "c" in dims:
+        c_len = array_like.shape[dims.index("c")]
+        if rgb and c_len not in {3, 4}:
+            raise ValueError(
+                "rgb is True, but c dimension does not have 3 or 4 channels"
+            )
+        if rgb or (rgb is None and c_coords is None and c_len in {3, 4}):
+            c_coords = ["r", "g", "b", "a"][:c_len]
         si_kwargs["c_coords"] = c_coords
     if "t" in dims:
         si_kwargs["t_coords"] = t_coords

--- a/spatial_image.py
+++ b/spatial_image.py
@@ -1178,13 +1178,13 @@ def to_spatial_image(
     axis_units: dict of str, optional
         Units names for the dim axes, e.g. {'x': 'millimeters', 't': 'seconds'}
 
+    t_coords: sequence of integers, strings or datetime64, optional
+        The 't' time coords can have int, float, or datetime64 type.
+
     c_coords: sequence integers or strings, optional
         If there is a 'c' dim, the coordinates for this channel/component dimension.
         A sequence of integers by default but can be strings describing the
         channels, e.g. ['r', 'g', 'b'].
-
-    t_coords: sequence of integers, strings or datetime64, optional
-        The 't' time coords can have int, float, or datetime64 type.
 
     Returns
     -------

--- a/spatial_image.py
+++ b/spatial_image.py
@@ -83,12 +83,12 @@ class SpatialImage(xr.DataArray):
         Multi-dimensional array that provides the image pixel values.
 
     dims:
-        Values should drawn from: {'c', 'x', 'y', 'z', 't'} for channel or
+        Values should be drawn from: {'c', 'x', 'y', 'z', 't'} for channel or
         component, first spatial direction, second spatial direction, third
         spatial dimension, and time, respectively.
 
     coords: sequence or dict of array_like objects, optional
-        For each {'x', 'y', 'z'} dim, 1-D np.float64 array specifing the
+        For each {'x', 'y', 'z'} dim, 1-D np.float64 array specifying the
         pixel location in the image's local coordinate system. The distance
         between subsequent coords elements must be uniform. The 'c' coords
         are a sequence of integers by default but can be strings describing the
@@ -1159,8 +1159,8 @@ def to_spatial_image(
 
     dims: sequence of hashable, optional
         Tuple specifying the data dimensions.
-        Values should drawn from: {'t', 'z', 'y', 'x', 'c'} for time, third spatial direction
-        second spatial direction, first spatial dimension, and channel or
+        Values should be drawn from: {'t', 'z', 'y', 'x', 'c'} for time, third spatial
+        direction second spatial direction, first spatial dimension, and channel or
         component, respectively spatial dimension, and time, respectively.
 
     scale: dict of floats, optional
@@ -1179,7 +1179,7 @@ def to_spatial_image(
         Units names for the dim axes, e.g. {'x': 'millimeters', 't': 'seconds'}
 
     c_coords: sequence integers or strings, optional
-        If there is a 'c' dim, the coordiantes for this channel/component dimension.
+        If there is a 'c' dim, the coordinates for this channel/component dimension.
         A sequence of integers by default but can be strings describing the
         channels, e.g. ['r', 'g', 'b'].
 

--- a/test_spatial_image.py
+++ b/test_spatial_image.py
@@ -131,6 +131,33 @@ def test_c_coords():
     assert np.array_equal(image.coords["c"], [0, 2])
 
 
+@pytest.mark.parametrize(
+    ("rgb", "c_len", "c_coords", "expected_c_coords"),
+    [
+        # Auto-detect
+        (None, 2, None, [0, 1]),  # default c_coords
+        (None, 3, [0, 1, 2], [0, 1, 2]),  # preserve c_coords
+        (None, 3, None, ["r", "g", "b"]),
+        (None, 4, None, ["r", "g", "b", "a"]),
+        # Disable
+        (False, 3, None, [0, 1, 2]),  # default c_coords
+        (False, 4, None, [0, 1, 2, 3]),
+        # Enforce RGB
+        (True, 3, [0, 1, 2], ["r", "g", "b"]),
+        (True, 4, [0, 1, 2, 3], ["r", "g", "b", "a"]),
+        pytest.param(True, 2, None, None, marks=pytest.mark.xfail(strict=True, raises=ValueError)),
+    ],
+)
+def test_rgb(rgb, c_len, c_coords, expected_c_coords):
+    array = np.random.random((3, 4, c_len))
+    dims = ("y", "x", "c")
+    image = si.to_spatial_image(
+        array, dims=dims, scale={"x": 4.0, "y": 3.0}, c_coords=c_coords, rgb=rgb,
+    )
+    assert si.is_spatial_image(image)
+    assert np.array_equal(image.coords["c"], expected_c_coords)
+
+
 def test_SpatialImage_type():
     si.SpatialImage is xr.DataArray
 


### PR DESCRIPTION
Higher-level tools may decide whether to represent/visualize channels as separate (gray) images or a combined RGB image. As shown in issue https://github.com/scverse/napari-spatialdata/issues/150, this can not be based solely on the number of channels, but the user/developer should have some level of control. This could be done by interpreting only certain channel names as RGB, and providing the user a utility for auto-detection or enabling/disabling change of channel names.

In this change, `rgb=False` preserves the passed channel names, `rgb=True` overrides them by `["r", "g", "b"]` and `rgb=None` auto-detects whether an image can be RGB.