### PR TITLE
ci bump

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-12]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- Add Python 3.12 to CI test matrix
- Add ARM macOS to CI testing
